### PR TITLE
Avoid header overlapping content title

### DIFF
--- a/style.css
+++ b/style.css
@@ -45,10 +45,9 @@
 /* INDEX PAGE */
 
 header {
-    position: fixed;
+    position: sticky;
     top: 0;
-    right: 0;
-    left: 0;
+    z-index: 1;
     background-color: #fff;
     width: 100%;
     height: 80px;
@@ -96,7 +95,7 @@ main {
 }
 
 .landing-box {
-    height: 100vh;
+    min-height: calc(100vh - 80px); /* 80px is header height */
 }
 
 .landing-box img {
@@ -142,7 +141,8 @@ main {
 }
 
 .lesson-box {
-    height: 100vh;
+    min-height: calc(100vh - 80px); /* 80px is header height */
+    padding-top: 80px; /* 80px is header height */
 }
 
 .lesson-box h1 {


### PR DESCRIPTION
- Using `position: sticky;` is more modern way of doing a "fixed header"
- Using `min-height` allows the box to expand beyond the height of the window if it needs to (especially important for shorter mobile devices)
- Adding `padding-top: 80px` gives room for the header to exist, so when clicking "Get Started", the title of the second box isn't hidden
- `z-index: 1` means "sit this box on the layer #1" (everything is on layer #0 by default), so the header will sit on top of everything else.
- Using `calc(100vh - 80px)` ensures the box height + header == 100vh